### PR TITLE
#39 ObjectValidation updated.

### DIFF
--- a/src/main/kotlin/pcf/crskdev/inval/id/ObjectValidation.kt
+++ b/src/main/kotlin/pcf/crskdev/inval/id/ObjectValidation.kt
@@ -34,8 +34,8 @@ package pcf.crskdev.inval.id
  * @receiver Applies ObjectValidationScope.
  * @return Validation.
  */
-fun <T> ObjectValidation(block: ObjectValidationScope<T>.() -> Unit): Validation<T> = { input, _, _ ->
-    val inputs = ObjectValidationScope(input).apply(block).inputs
+fun <T> ObjectValidation(block: ObjectValidationScope<T>.(T) -> Unit): Validation<T> = { input, _, _ ->
+    val inputs = ObjectValidationScope<T>().apply { block(input) }.inputs
     val builder = ValidationException.Builder()
     inputs.map { it() }.forEach {
         it.onFailure { t ->
@@ -52,7 +52,7 @@ fun <T> ObjectValidation(block: ObjectValidationScope<T>.() -> Unit): Validation
  * @property input Input value.
  * @constructor Create empty Object validation scope.
  */
-class ObjectValidationScope<T> internal constructor(val input: T) {
+class ObjectValidationScope<T> internal constructor() {
 
     /**
      * Property Inputs.

--- a/src/test/kotlin/pcf/crskdev/inval/id/ObjectValidationTestCase.kt
+++ b/src/test/kotlin/pcf/crskdev/inval/id/ObjectValidationTestCase.kt
@@ -40,12 +40,12 @@ class ObjectValidationTestCase : StringSpec({
         }
         val emailRule = RegexValidation("^(.+)@(.+)$")("Not a valid email.")
 
-        val input = ObjectValidation<Account> {
-            ComposedValidation(empty, emailRule) validates input.email withId "email"
-            ObjectValidation<Info> {
-                empty validates input.address withId "address"
-                empty validates input.phone withId "phone".toId()
-            } validates input.info withId "info"
+        val input = ObjectValidation<Account> { acc ->
+            ComposedValidation(empty, emailRule) validates acc.email withId "email"
+            ObjectValidation<Info> { info ->
+                empty validates info.address withId "address"
+                empty validates info.phone withId "phone".toId()
+            } validates acc.info withId "info"
         } validates account withId "account"
 
         input.validations.size shouldBe 1


### PR DESCRIPTION
ObjectValidation now exposes input as argument, not as a scope member in order be to be consistent with Validation function helper that follows that rule.

close #39